### PR TITLE
PR-6471 Refactor splitting functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ be reused to perform the same manipulation on many polygons.
 from geo_extensions import Transformer
 from geo_extensions.transformations import (
     simplify_polygon,
-    split_polygon_on_antimeridian,
+    split_polygon_on_antimeridian_ccw,
 )
 
 
@@ -37,7 +37,7 @@ def my_custom_transformation(polygon):
 transformer = Transformer([
     simplify_polygon(0.1),
     my_custom_transformation,
-    split_polygon_on_antimeridian,
+    split_polygon_on_antimeridian_ccw,
 ])
 
 final_polygons = transformer.transform([

--- a/geo_extensions/__init__.py
+++ b/geo_extensions/__init__.py
@@ -1,30 +1,30 @@
 from geo_extensions.checks import (
-    fixed_size_polygon_crosses_antimeridian,
-    polygon_crosses_antimeridian,
+    polygon_crosses_antimeridian_ccw,
+    polygon_crosses_antimeridian_fixed_size,
 )
 from geo_extensions.transformations import (
     drop_z_coordinate,
     reverse_polygon,
     simplify_polygon,
-    split_polygon_on_antimeridian,
+    split_polygon_on_antimeridian_ccw,
 )
 from geo_extensions.transformer import Transformer, to_polygons
 from geo_extensions.types import Transformation, TransformationResult
 
 default_transformer = Transformer([
     simplify_polygon(0.1),
-    split_polygon_on_antimeridian,
+    split_polygon_on_antimeridian_ccw,
 ])
 
 
 __all__ = (
     "default_transformer",
     "drop_z_coordinate",
-    "fixed_size_polygon_crosses_antimeridian",
-    "polygon_crosses_antimeridian",
+    "polygon_crosses_antimeridian_ccw",
+    "polygon_crosses_antimeridian_fixed_size",
     "reverse_polygon",
     "simplify_polygon",
-    "split_polygon_on_antimeridian",
+    "split_polygon_on_antimeridian_ccw",
     "to_polygons",
     "Transformation",
     "TransformationResult",

--- a/geo_extensions/__init__.py
+++ b/geo_extensions/__init__.py
@@ -7,6 +7,7 @@ from geo_extensions.transformations import (
     reverse_polygon,
     simplify_polygon,
     split_polygon_on_antimeridian_ccw,
+    split_polygon_on_antimeridian_fixed_size,
 )
 from geo_extensions.transformer import Transformer, to_polygons
 from geo_extensions.types import Transformation, TransformationResult
@@ -25,6 +26,7 @@ __all__ = (
     "reverse_polygon",
     "simplify_polygon",
     "split_polygon_on_antimeridian_ccw",
+    "split_polygon_on_antimeridian_fixed_size",
     "to_polygons",
     "Transformation",
     "TransformationResult",

--- a/geo_extensions/checks.py
+++ b/geo_extensions/checks.py
@@ -1,7 +1,7 @@
 from shapely.geometry import Polygon
 
 
-def polygon_crosses_antimeridian(polygon: Polygon) -> bool:
+def polygon_crosses_antimeridian_ccw(polygon: Polygon) -> bool:
     """Checks if the longitude coordinates 'wrap around' the 180/-180 line.
 
     The polygon must be oriented in counter-clockwise order.
@@ -13,7 +13,7 @@ def polygon_crosses_antimeridian(polygon: Polygon) -> bool:
     return not polygon.exterior.is_ccw
 
 
-def fixed_size_polygon_crosses_antimeridian(
+def polygon_crosses_antimeridian_fixed_size(
     polygon: Polygon,
     min_lon_extent: float,
 ) -> bool:

--- a/geo_extensions/transformations.py
+++ b/geo_extensions/transformations.py
@@ -38,13 +38,13 @@ even in the general case, because such a polygon will appear to be clockwise
 ordered in the shapely flat space.
 """
 
-from typing import Generator, List, Tuple
+from typing import List, Tuple
 
 from shapely.geometry import LineString, Polygon
 from shapely.geometry.polygon import orient
 from shapely.ops import linemerge, polygonize, unary_union
 
-from geo_extensions.checks import polygon_crosses_antimeridian
+from geo_extensions.checks import polygon_crosses_antimeridian_ccw
 from geo_extensions.types import Transformation, TransformationResult
 
 Point = Tuple[float, float]
@@ -77,8 +77,9 @@ def drop_z_coordinate(polygon: Polygon) -> TransformationResult:
     )
 
 
-def split_polygon_on_antimeridian(polygon: Polygon) -> Generator[Polygon, None, None]:
-    """Perform adjustment when the polygon crosses the antimeridian.
+def split_polygon_on_antimeridian_ccw(polygon: Polygon) -> TransformationResult:
+    """Perform adjustment when the polygon crosses the antimeridian and is known
+    to be wound in counter clockwise order.
 
     CMR requires the polygon to be split into two separate polygons to avoid it
     being interpreted as wrapping the long way around the Earth.
@@ -90,7 +91,7 @@ def split_polygon_on_antimeridian(polygon: Polygon) -> Generator[Polygon, None, 
     :returns: a generator yielding the split polygons
     """
 
-    if not polygon_crosses_antimeridian(polygon):
+    if not polygon_crosses_antimeridian_ccw(polygon):
         yield polygon
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "geo-extensions"
-version = "0.1.3"
+version = "0.2.0"
 description = ""
 authors = ["Rohan Weeden <reweeden@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,16 +1,16 @@
 from shapely.geometry import Polygon
 
 from geo_extensions.checks import (
-    fixed_size_polygon_crosses_antimeridian,
-    polygon_crosses_antimeridian,
+    polygon_crosses_antimeridian_ccw,
+    polygon_crosses_antimeridian_fixed_size,
 )
 
 
-def test_polygon_crosses_antimeridian_simple(centered_rectangle):
-    assert polygon_crosses_antimeridian(centered_rectangle) is False
+def test_polygon_crosses_antimeridian_ccw_simple(centered_rectangle):
+    assert polygon_crosses_antimeridian_ccw(centered_rectangle) is False
 
 
-def test_polygon_crosses_antimeridian_tricky():
+def test_polygon_crosses_antimeridian_ccw_tricky():
     r"""A polygon that looks something like this, centered at 0, 0:
         --------
         \      /
@@ -21,10 +21,10 @@ def test_polygon_crosses_antimeridian_tricky():
         (-30., 10.), (-10., 0.), (-30., -10.),
         (30., 10.), (10., 0.), (30., -10.), (-30., 10.),
     ])
-    assert polygon_crosses_antimeridian(polygon) is False
+    assert polygon_crosses_antimeridian_ccw(polygon) is False
 
 
-def test_polygon_crosses_antimeridian_tricky_crosses():
+def test_polygon_crosses_antimeridian_ccw_tricky_crosses():
     r"""A polygon that looks something like this, crossing the IDL:
         --------
         \      /
@@ -35,15 +35,15 @@ def test_polygon_crosses_antimeridian_tricky_crosses():
         (150., 10.), (170., 0.), (150., -10.),
         (-150., 10.), (-170., 0.), (-150., -10.), (150., 10.),
     ])
-    assert polygon_crosses_antimeridian(polygon) is True
+    assert polygon_crosses_antimeridian_ccw(polygon) is True
 
 
-def test_fixed_size_polygon_crosses_antimeridian_simple(centered_rectangle):
-    assert fixed_size_polygon_crosses_antimeridian(centered_rectangle, 20) is False
-    assert fixed_size_polygon_crosses_antimeridian(centered_rectangle, 179) is True
+def test_polygon_crosses_antimeridian_fixed_size_simple(centered_rectangle):
+    assert polygon_crosses_antimeridian_fixed_size(centered_rectangle, 20) is False
+    assert polygon_crosses_antimeridian_fixed_size(centered_rectangle, 179) is True
 
 
-def test_fixed_size_polygon_crosses_antimeridian_tricky_crosses():
+def test_polygon_crosses_antimeridian_fixed_size_tricky_crosses():
     r"""A polygon that looks something like this, crossing the IDL:
         --------
         \      /
@@ -54,4 +54,15 @@ def test_fixed_size_polygon_crosses_antimeridian_tricky_crosses():
         (150., 10.), (170., 0.), (150., -10.),
         (-150., 10.), (-170., 0.), (-150., -10.), (150., 10.),
     ])
-    assert fixed_size_polygon_crosses_antimeridian(polygon, 30) is True
+    assert polygon_crosses_antimeridian_fixed_size(polygon, 30) is True
+
+
+def test_polygon_crosses_antimeridian_fixed_size_antarctica():
+    r"""A real polygon from ALOS2 granule ALOS2014555550-140830 which is located
+    close to the south pole, and also crosses the antimeridian
+    """
+    polygon = Polygon([
+        (-164.198, -82.125), (172.437, -83.885), (165.618, -80.869),
+        (-176.331, -79.578), (-164.198, -82.125),
+    ])
+    assert polygon_crosses_antimeridian_fixed_size(polygon, 40) is True

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -7,6 +7,7 @@ from shapely.geometry import Polygon
 from geo_extensions.transformations import (
     drop_z_coordinate,
     split_polygon_on_antimeridian_ccw,
+    split_polygon_on_antimeridian_fixed_size,
 )
 
 
@@ -192,5 +193,34 @@ def test_split_polygon_on_antimeridian_ccw_opera_example():
             (-178.918, 66.663),
             (-179.999, 66.663),
             (-179.999, 66.140),
+        ],
+    ]
+
+
+def test_split_polygon_on_antimeridian_fixed_size_alos2_example():
+    """Example from ALOS2: ALOS2014555550-140830"""
+    polygon = Polygon([
+        (-164.198, -82.125), (172.437, -83.885), (165.618, -80.869),
+        (-176.331, -79.578), (-164.198, -82.125),
+    ])
+    polygons = split_polygon_on_antimeridian_fixed_size(40)(polygon)
+
+    # Comparing the polygons directly doesn't seem to work for some reason.
+    coords = [list(poly.boundary.coords) for poly in polygons]
+    assert all(poly.is_ccw for poly in polygons)
+    assert coords == [
+        [
+            (179.999, -79.84040535150407),
+            (165.61799999999994, -80.869),
+            (172.437, -83.885),
+            (179.999, -83.31530686924889),
+            (179.999, -79.84040535150407),
+        ],
+        [
+            (-179.999, -83.31530686924889),
+            (-164.198, -82.125),
+            (-176.331, -79.578),
+            (-179.999, -79.84040535150407),
+            (-179.999, -83.31530686924889),
         ],
     ]


### PR DESCRIPTION
The current `split_polygon_on_antimeridian` function actually has a slightly hidden requirement that the input polygons must be in counter clockwise order. This function is now renamed to better reflect that and an additional function is added to split polygons based on a heuristic.

New functions:
- `polygon_crosses_antimeridian_ccw`
- `polygon_crosses_antimeridian_fixed_size`
- `split_polygon_on_antimeridian_ccw`
- `split_polygon_on_antimeridian_fixed_size`

Old functions that are being replaced:
- `polygon_crosses_antimeridian`
- `fixed_size_polygon_crosses_antimeridian`
- `split_polygon_on_antimeridian`