### PR TITLE
PR-6825 Fix polygon self intersection edge case for split polygons

### DIFF
--- a/geo_extensions/transformations.py
+++ b/geo_extensions/transformations.py
@@ -156,13 +156,23 @@ def _shift_polygon_back(polygon: Polygon) -> Polygon:
     ])
 
 
-def _adjust_lon(lon: float, max_lon: float) -> float:
+def _adjust_lon(
+    lon: float,
+    max_lon: float,
+    clamp_min: float = -179.999,
+    clamp_max: float = 179.999,
+) -> float:
     if lon > 180.0:
-        return lon - 360
+        lon -= 360
     elif lon == 180.0 and max_lon == 180.0:
-        return 179.999
+        return clamp_max
     elif lon == 180.0:
-        return -179.999
+        return clamp_min
+
+    if lon > clamp_max:
+        return clamp_max
+    if lon < clamp_min:
+        return clamp_min
 
     return lon
 
@@ -188,7 +198,7 @@ def _ignore_polygon(polygon: Polygon) -> bool:
     # polygons that are contained within the +/-0.001 degrees around the
     # antimeridian. Due to possible floating point errors in the distance
     # calculation, we are a little generous in this trimming and set our
-    # threshold to 0.0015 instead of just 0.0015
+    # threshold to 0.0015 instead of just 0.001
     #
     # For instance:
     # >>> 180.001-180

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "geo-extensions"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Rohan Weeden <reweeden@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -46,6 +46,7 @@ def test_drop_z_coordinate_noop():
 def test_split_polygon_on_antimeridian_ccw_returns_ccw(polygon):
     for poly in split_polygon_on_antimeridian_ccw(polygon):
         assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
 
 
 @given(
@@ -80,10 +81,15 @@ def test_split_polygon_on_antimeridian_ccw_centered_noop(centered_rectangle):
 
 def test_split_polygon_on_antimeridian_ccw_centered(antimeridian_centered_rectangle):
     """Polygon is centered on IDL"""
-    split_polygons = list(
+    polygons = list(
         split_polygon_on_antimeridian_ccw(antimeridian_centered_rectangle),
     )
-    assert split_polygons == [
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
+
+    assert polygons == [
         Polygon([
             (179.999, -10),
             (179.999, 10.),
@@ -104,10 +110,15 @@ def test_split_polygon_on_antimeridian_ccw_centered(antimeridian_centered_rectan
 def test_split_polygon_on_antimeridian_ccw_crosses_multiple_times(
     multi_crossing_polygon,
 ):
-    split_polygons = list(
+    polygons = list(
         split_polygon_on_antimeridian_ccw(multi_crossing_polygon),
     )
-    assert split_polygons == [
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
+
+    assert polygons == [
         Polygon([
             (179.999, -10),
             (179.999, -4),
@@ -129,8 +140,13 @@ def test_split_polygon_on_antimeridian_ccw_west():
         (-179., 70.), (170., 70.)
     ])
     assert not polygon.exterior.is_ccw
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
 
-    assert list(split_polygon_on_antimeridian_ccw(polygon)) == [
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
+
+    assert polygons == [
         Polygon([
             (179.999, 60.),
             (179.999, 70.),
@@ -155,8 +171,13 @@ def test_split_polygon_on_antimeridian_ccw_east():
         (-170., 70.), (179., 70.)
     ])
     assert not polygon.exterior.is_ccw
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
 
-    assert list(split_polygon_on_antimeridian_ccw(polygon)) == [
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
+
+    assert polygons == [
         Polygon([
             (179.999, 60.),
             (179.999, 70.),
@@ -183,7 +204,11 @@ def test_split_polygon_on_antimeridian_ccw_alos_example():
         (-179.392, 50.281),
         (179.648, 50.172),
     ])
-    polygons = split_polygon_on_antimeridian_ccw(polygon)
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
 
     # Comparing the polygons directly doesn't seem to work for some reason.
     coords = [list(poly.boundary.coords) for poly in polygons]
@@ -213,7 +238,11 @@ def test_split_polygon_on_antimeridian_ccw_alos2_example():
         (166.084, -76.163),
         (164.037, -79.438),
     ])
-    polygons = split_polygon_on_antimeridian_ccw(polygon)
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
 
     # Comparing the polygons directly doesn't seem to work for some reason.
     coords = [list(poly.boundary.coords) for poly in polygons]
@@ -247,7 +276,11 @@ def test_split_polygon_on_antimeridian_ccw_opera_example():
         -178.918,
     )
     polygon = shapely.geometry.box(east, north, west, south, ccw=True)
-    polygons = split_polygon_on_antimeridian_ccw(polygon)
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
 
     # Comparing the polygons directly doesn't seem to work for some reason.
     coords = [list(poly.boundary.coords) for poly in polygons]
@@ -275,11 +308,14 @@ def test_split_polygon_on_antimeridian_fixed_size_alos2_example():
         (-164.198, -82.125), (172.437, -83.885), (165.618, -80.869),
         (-176.331, -79.578), (-164.198, -82.125),
     ])
-    polygons = split_polygon_on_antimeridian_fixed_size(40)(polygon)
+    polygons = list(split_polygon_on_antimeridian_fixed_size(40)(polygon))
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
 
     # Comparing the polygons directly doesn't seem to work for some reason.
     coords = [list(poly.boundary.coords) for poly in polygons]
-    assert all(poly.is_ccw for poly in polygons)
     assert coords == [
         [
             (-164.198, -82.125),

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -195,6 +195,38 @@ def test_split_polygon_on_antimeridian_ccw_east():
     ]
 
 
+def test_split_polygon_on_antimeridian_ccw_close_point():
+    """Polygon has a point that is extremely close to the antimeridian"""
+    polygon = Polygon([
+        (179.999999, 70.),
+        (179., 60.), (-170., 60.),
+        (-170., 70.), (179., 70.)
+    ])
+    assert not polygon.exterior.is_ccw
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
+
+    assert polygons == [
+        Polygon([
+            (179.999, 60.),
+            (179.999, 70.),
+            (179.999, 70.),
+            (179., 60.),
+            (179.999, 60.),
+        ]),
+        Polygon([
+            (-179.999, 70.),
+            (-179.999, 60.),
+            (-170., 60.),
+            (-170., 70.),
+            (-179.999, 70.),
+        ]),
+    ]
+
+
 def test_split_polygon_on_antimeridian_ccw_alos_example():
     """Example from ALOS mission: ALPSRP237090990-L1.1"""
     polygon = Polygon([
@@ -298,6 +330,40 @@ def test_split_polygon_on_antimeridian_ccw_opera_example():
             (-178.918, 66.140),
             (-178.918, 66.663),
             (-179.999, 66.663),
+        ],
+    ]
+
+
+def test_split_polygon_on_antimeridian_ccw_opera_example_pre_split():
+    """Example from OPERA CLSC which crosses the IDL but is pre-split:
+
+    OPERA_L2_CSLC-S1_T001-000688-IW1_20250504T183220Z_20250505T112029Z_S1A_VV_v1.1
+    """
+    polygon = Polygon([
+        (180, 64.67712437067621),
+        (180, 64.50629047887854),
+        (179.9988239237079, 64.50640025835617),
+        (179.9167734717595, 64.51400884003007),
+        (179.999315144991, 64.6771877237759),
+        (180, 64.67712437067621),
+    ])
+    assert not polygon.exterior.is_ccw
+    polygons = list(split_polygon_on_antimeridian_ccw(polygon))
+
+    for poly in polygons:
+        assert poly.exterior.is_ccw
+        assert poly.exterior.is_valid
+
+    # Comparing the polygons directly doesn't seem to work for some reason.
+    coords = [list(poly.boundary.coords) for poly in polygons]
+    assert coords == [
+        [
+            (179.999, 64.67712437067621),
+            (179.999, 64.6771877237759),
+            (179.91677347175948, 64.51400884003007),
+            (179.99882392370796, 64.50640025835617),
+            (179.999, 64.50629047887854),
+            (179.999, 64.67712437067621),
         ],
     ]
 


### PR DESCRIPTION
What was happening is that the input polygon contained a point between 180 and 179.999. The points that landed exactly on the boundary were then adjusted to 179.999 putting them actually further from the boundary than the super close points which caused the geometry to self intersect.

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>