### PR TITLE
Fix shapely deprecation warning

### DIFF
--- a/geo_extensions/transformations.py
+++ b/geo_extensions/transformations.py
@@ -65,7 +65,13 @@ def simplify_polygon(tolerance: float, preserve_topology: bool = True) -> Transf
         """Perform a shapely simplify operation on the polygon."""
         # NOTE(reweeden): I have been unable to produce a situation where a
         # polygon is simplified to a geometry other than Polygon.
-        yield cast(Polygon, polygon.simplify(tolerance, preserve_topology))
+        yield cast(
+            Polygon,
+            polygon.simplify(
+                tolerance,
+                preserve_topology=preserve_topology,
+            ),
+        )
 
     return simplify
 


### PR DESCRIPTION
This was generating a deprecation warning on newer versions of shapely. At some point shapely will require `preserve_topology` to be passed as a kwarg.

<details>
<summary>Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>