### PR TITLE
Update module to handle both geodetic and cartesian coordinate systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,3 @@ final_polygons = transformer.transform([
     ])
 ])
 ```
-
-The default transformer performs some standard transformations that are usually
-needed. Check the definition for what those transformations are.
-
-```python
-from geo_extensions import default_transformer
-
-
-WKT = "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"
-
-polygons = default_transformer.from_wkt(WKT)
-```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ This library consists of some common functions needed to manipulate polygons
 before posting them to CMR. This includes functions to split polygons along
 the antimeridian and perform other 'clean up' operations.
 
+## Beware the Coordinate System
+
+CMR supports two modes for interpreting how the points of a polygon are supposed
+to be connected to each other: Geodetic and Cartesian.
+
+In the geodetic coordinate system, points are connected to each other by the
+shortest arc on a  spherical approximation of the Earth. This is the closest
+system to how a  satellite would actually be seeing the area in the real world.
+However, it is not typically the way that polygons would be rendered in a web
+search tool as these usually use web mercator projection.
+
+In the cartesian coordinate system, points are connected to each other more or
+less along longitude and latitude lines. This means that points will be
+connected by straight lines when viewed in a mercator projection, which is
+useful for web tools but not necessarily an accurate representation of the data
+acquired by the satellite.
+
+Keep these differences in mind when implementing a polygon transformation
+pipeline, and be aware of what mode the collection you are posting to is set up
+in. As a general rule, the higher the point density is on a polygon, the less
+the difference between the two coordinate system interpretations will be because
+each line segment will be shorter. It is therefore a good idea to start your
+pipeline with a 'densify' operation, do the desired transformations, and then
+simplify at the end.
 
 ## Example Usage
 
@@ -35,9 +59,9 @@ def my_custom_transformation(polygon):
 
 
 transformer = Transformer([
-    simplify_polygon(0.1),
     my_custom_transformation,
     split_polygon_on_antimeridian_ccw,
+    simplify_polygon(0.1),
 ])
 
 final_polygons = transformer.transform([

--- a/geo_extensions/__init__.py
+++ b/geo_extensions/__init__.py
@@ -13,14 +13,7 @@ from geo_extensions.transformations import (
 from geo_extensions.transformer import Transformer, to_polygons
 from geo_extensions.types import Transformation, TransformationResult
 
-default_transformer = Transformer([
-    simplify_polygon(0.1),
-    split_polygon_on_antimeridian_ccw,
-])
-
-
 __all__ = (
-    "default_transformer",
     "densify_polygon",
     "drop_z_coordinate",
     "polygon_crosses_antimeridian_ccw",

--- a/geo_extensions/__init__.py
+++ b/geo_extensions/__init__.py
@@ -3,6 +3,7 @@ from geo_extensions.checks import (
     polygon_crosses_antimeridian_fixed_size,
 )
 from geo_extensions.transformations import (
+    densify_polygon,
     drop_z_coordinate,
     reverse_polygon,
     simplify_polygon,
@@ -20,6 +21,7 @@ default_transformer = Transformer([
 
 __all__ = (
     "default_transformer",
+    "densify_polygon",
     "drop_z_coordinate",
     "polygon_crosses_antimeridian_ccw",
     "polygon_crosses_antimeridian_fixed_size",

--- a/geo_extensions/checks.py
+++ b/geo_extensions/checks.py
@@ -1,12 +1,25 @@
+"""Geospatial aware polygon tests.
+
+When polygons are required to be in counter-clockwise order, this means counter-
+clockwise in the real world, on the surface of the Earth. Specifically, polygons
+MUST NOT be oriented using the shapely `orient` function, as this function
+treats polygons as existing on an infinite flat plane and may end up actually
+mis-ordering the polygons. Knowing that a polygon is in fact counter-clockwise
+ordered on the surface of the Earth makes the shapely `is_ccw` property a very
+useful and easy check to determine if the polygon crosses the antimeridian, as
+in this case, the polygon will appear to be mis-ordered in the infinite flat
+plane space.
+"""
+
 from shapely.geometry import Polygon
 
 
 def polygon_crosses_antimeridian_ccw(polygon: Polygon) -> bool:
     """Checks if the longitude coordinates 'wrap around' the 180/-180 line.
 
-    The polygon must be oriented in counter-clockwise order.
-
-    :param polygon: the polygon to check
+    :param polygon: the polygon to check, must be known to be in counter-
+        clockwise order.
+    :returns: true if the polygon crosses the antimeridian
     """
 
     # Polygons crossing the antimeridian will appear to be mis-ordered or
@@ -25,6 +38,7 @@ def polygon_crosses_antimeridian_fixed_size(
     :param min_lon_extent: the lower bound for the distance between the
         longitude values of the bounding box enclosing the entire polygon.
         Must be between (0, 180) exclusive.
+    :returns: true if the polygon crosses the antimeridian
     """
     assert 0 < min_lon_extent < 180
 

--- a/geo_extensions/transformations/__init__.py
+++ b/geo_extensions/transformations/__init__.py
@@ -40,8 +40,10 @@ from geo_extensions.transformations.cartesian import (
     split_polygon_on_antimeridian_fixed_size,
 )
 from geo_extensions.transformations.general import drop_z_coordinate, reverse_polygon
+from geo_extensions.transformations.geodetic import densify_polygon
 
 __all__ = (
+    "densify_polygon",
     "drop_z_coordinate",
     "reverse_polygon",
     "simplify_polygon",

--- a/geo_extensions/transformations/__init__.py
+++ b/geo_extensions/transformations/__init__.py
@@ -1,0 +1,50 @@
+"""Geospatial helpers to prepare spatial extents for submission to CMR.
+
+CMR can interpret polygons as being in one of two coordinate systems, Cartesian
+or Geodetic. Transformation helpers that must assume they are working in one of
+these two coordinate systems all found in their own submodules `cartesian` and
+`geodetic`.
+
+Each coordinate system also has its own set of constraints that polygons must
+follow. These constraints are documented in the corresponding module for the
+coordinate system.
+
+There are some additional constraints that depend on the data format being used.
+For UMM-G, polygons must
+    - Be counter clockwise ordered
+    - Include closure points
+
+In this module, polygons are expected to follow the UMM-G constraints.
+
+A table describing the differences between data format requirements can be found
+here:
+https://wiki.earthdata.nasa.gov/display/CMR/Polygon+Support+in+CMR+Search+and+Ingest+Interfaces
+
+There are several challenges with representing polygons on a spherical surface,
+the primary being that since all straight lines will 'wrap around' the surface,
+it becomes impossible to unabmiguously define a polygon using only an ordered
+set of points. This is the primary reason for the CMR requirements, as those
+additional constraints make it possible to determine exactly which area is
+meant by a set of points. Unfortunately, the polygons that we get from the data
+provider won't necessarily meet those same requirements and we must use mission
+specific knowledge to convert them to an unambiguous set of polygons to be used
+by CMR.
+
+This module aims to assist in that conversion to unambiguous polygons using the
+CMR additional requirements.
+"""
+
+from geo_extensions.transformations.cartesian import (
+    simplify_polygon,
+    split_polygon_on_antimeridian_ccw,
+    split_polygon_on_antimeridian_fixed_size,
+)
+from geo_extensions.transformations.general import drop_z_coordinate, reverse_polygon
+
+__all__ = (
+    "drop_z_coordinate",
+    "reverse_polygon",
+    "simplify_polygon",
+    "split_polygon_on_antimeridian_ccw",
+    "split_polygon_on_antimeridian_fixed_size",
+)

--- a/geo_extensions/transformations/general.py
+++ b/geo_extensions/transformations/general.py
@@ -1,0 +1,20 @@
+"""Geospatial helpers that work the same regardless of which coordinate system
+the polygons are using.
+"""
+
+from shapely.geometry import Polygon
+
+from geo_extensions.types import TransformationResult
+
+
+def reverse_polygon(polygon: Polygon) -> TransformationResult:
+    """Perform a shapely reverse operation on the polygon."""
+    yield polygon.reverse()
+
+
+def drop_z_coordinate(polygon: Polygon) -> TransformationResult:
+    """Drop the third element from each coordinate in the polygon."""
+    yield Polygon(
+        (x, y)
+        for x, y, *_ in polygon.exterior.coords
+    )

--- a/geo_extensions/transformations/general.py
+++ b/geo_extensions/transformations/general.py
@@ -15,6 +15,9 @@ def reverse_polygon(polygon: Polygon) -> TransformationResult:
 def drop_z_coordinate(polygon: Polygon) -> TransformationResult:
     """Drop the third element from each coordinate in the polygon."""
     yield Polygon(
-        (x, y)
-        for x, y, *_ in polygon.exterior.coords
+        shell=((x, y) for x, y, *_ in polygon.exterior.coords),
+        holes=[
+            ((x, y) for x, y, *_ in interior.coords)
+            for interior in polygon.interiors
+        ],
     )

--- a/geo_extensions/transformations/geodetic.py
+++ b/geo_extensions/transformations/geodetic.py
@@ -1,0 +1,97 @@
+"""Geospatial helpers for working in a geodetic coordinate system.
+
+CMR has the following constraints for geodetic polygons:
+    - The implemented Geodetic model uses the great circle distance to connect
+        two vertices for constructing a polygon area or line. If there is not
+        enough density (that is, the number of points) for a set of vertices,
+        then the line or the polygon area might be misinterpreted or the
+        metadata might be considered invalid.
+    - Any single spatial area may cross the International Date Line and/or Poles.
+    - Any single spatial area may not cover more than one half of the earth.
+
+Taken from: <https://wiki.earthdata.nasa.gov/spaces/CMR/pages/50036858/
+CMR+Data+Partner+User+Guide#CMRDataPartnerUserGuide-GeodeticCoordinateSystem>
+
+This module contains helpers to fulfill the geodetic system CMR requirements.
+"""
+
+import itertools
+import math
+from collections.abc import Generator
+from typing import TypeVar, cast
+
+from pygeodesy.sphericalTrigonometry import LatLon
+from shapely.coords import CoordinateSequence
+from shapely.geometry import Polygon
+
+from geo_extensions.types import Transformation, TransformationResult
+
+T = TypeVar("T")
+
+
+def densify_polygon(max_edge_len_meters: float) -> Transformation:
+    """GEODETIC: Create a transformation that increases the point density of a
+    polygon along great circle arcs between each point.
+
+    In a sense, this is an opposite operation from 'simplify'.
+
+    :param max_edge_len_meters: The maximum desired length for any line segment.
+        Must be greater than 0.
+    :returns: a callable transformation using the passed parameters
+    """
+    if max_edge_len_meters <= 0:
+        raise ValueError("'max_edge_len_meters' must be greater than 0")
+
+    def densify(polygon: Polygon) -> TransformationResult:
+        """Densify the polygon by adding additional points along the great
+        circle arcs between the existing points.
+        """
+        yield Polygon(
+            shell=_densify_ring(polygon.exterior.coords, max_edge_len_meters),
+            holes=[
+                _densify_ring(interior.coords, max_edge_len_meters)
+                for interior in polygon.interiors
+            ],
+        )
+
+    return densify
+
+
+def _densify_ring(
+    coords: CoordinateSequence,
+    max_edge_len_meters: float,
+) -> Generator[tuple[float, ...]]:
+    assert max_edge_len_meters > 0
+
+    if len(coords) < 2:
+        yield from coords
+        return
+
+    for c1, c2 in itertools.pairwise(coords):
+        p1 = _shapely_to_pygeodesy(c1)
+        p2 = _shapely_to_pygeodesy(c2)
+
+        yield c1
+
+        distance = p1.distanceTo(p2)
+        if distance < max_edge_len_meters:
+            continue
+
+        segments_needed = math.ceil(distance / max_edge_len_meters)
+        points_needed = segments_needed - 1
+        fraction = 1 / segments_needed
+
+        # TODO(reweeden): Safeguard for low edge lengths that would generate
+        # 'absurdly large' amounts of points?
+        for i in range(points_needed):
+            p_new = cast(
+                LatLon,
+                p1.intermediateTo(p2, fraction=fraction * (i + 1)),
+            )
+            yield (p_new.lon, p_new.lat)
+
+    yield c2
+
+
+def _shapely_to_pygeodesy(coord: tuple[float, ...]) -> LatLon:
+    return LatLon(coord[1], coord[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [{include = "geo_extensions"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 
+pygeodesy = "^25.9.9"
 shapely = "^2.0.3"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "geo-extensions"
-version = "0.3.1"
+version = "0.4.0"
 description = ""
 authors = ["Rohan Weeden <reweeden@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_geo_extensions.py
+++ b/tests/test_geo_extensions.py
@@ -1,12 +1,21 @@
 from shapely.geometry import Polygon
 
-from geo_extensions import default_transformer
+from geo_extensions import (
+    Transformer,
+    simplify_polygon,
+    split_polygon_on_antimeridian_ccw,
+)
 
 
 def test_default_transformer(data_path):
     wkt_path = data_path / "OPERA_L2_RTC-S1_T114-243299-IW1_20230722T122534Z_20230818T184635Z_S1A_30_v0.4.wkt"
 
-    polygons = default_transformer.from_wkt(wkt_path.read_text())
+    transformer = Transformer([
+        split_polygon_on_antimeridian_ccw,
+        simplify_polygon(0.1),
+    ])
+
+    polygons = transformer.from_wkt(wkt_path.read_text())
     assert polygons == [
         Polygon([
             (-64.18242781701073, 80.92318071697005),

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -184,6 +184,37 @@ def test_drop_z_coordinate_noop():
     assert list(drop_z_coordinate(polygon)) == [polygon]
 
 
+def test_drop_z_coordinate_holes():
+    polygon = Polygon(
+        shell=[
+            (100, 10, 10),
+            (100, 0, 10),
+            (80, 0, 10),
+            (80, 10, 10),
+            (100, 10, 10),
+        ],
+        holes=[
+            [(93, 8, 10), (83, 8, 10), (83, 2, 10), (93, 8, 10)],
+            [(97, 2, 10), (97, 8, 10), (87, 2, 10), (97, 2, 10)],
+        ],
+    )
+    assert list(drop_z_coordinate(polygon)) == [
+        Polygon(
+            shell=[
+                (100, 10),
+                (100, 0),
+                (80, 0),
+                (80, 10),
+                (100, 10),
+            ],
+            holes=[
+                [(93, 8), (83, 8), (83, 2), (93, 8)],
+                [(97, 2), (97, 8), (87, 2), (97, 2)],
+            ],
+        ),
+    ]
+
+
 @given(polygon=strategies.rectangles())
 @settings(suppress_health_check=[HealthCheck.filter_too_much])
 def test_split_polygon_on_antimeridian_ccw_returns_ccw(polygon):

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -58,28 +58,22 @@ def test_simplify_line():
 
 def test_densify():
     polygon = Polygon([
-        (50, 70),
-        (50, 80),
-        (0, 80),
-        (0, 70),
-        (50, 70),
+        (50, 75),
+        (10, 80),
+        (0, 77),
+        (40, 70),
+        (50, 75),
     ])
 
-    assert list(densify_polygon(500000)(polygon)) == [
+    assert list(densify_polygon(50_000)(polygon)) == [
         Polygon([
-            (50, 70),
-            (50, 73.33333333333333),
-            (50, 76.66666666666667),
-            (50, 80),
-            (25, 80.92053252671789),
-            (0, 80),
-            (0, 76.66666666666667),
-            (0, 73.33333333333333),
-            (0, 70),
-            (11.94262888488008, 71.29264444333815),
-            (24.999999999999996, 71.7438759890997),
-            (38.05737111511993, 71.29264444333815),
-            (50, 70),
+            (50, 75),
+            (34.100003241169595, 78.2028289318241),
+            (10, 80),
+            (0, 77),
+            (24.297878219303588, 74.40374356383884),
+            (40, 70),
+            (50, 75),
         ]),
     ]
 
@@ -104,34 +98,25 @@ def test_densify_with_holes():
         ],
     )
 
-    assert list(densify_polygon(500000)(polygon)) == [
+    assert list(densify_polygon(50_000)(polygon)) == [
         Polygon(
             shell=[
                 (50, 70),
-                (50, 73.33333333333333),
-                (50, 76.66666666666667),
                 (50, 80),
-                (25, 80.92053252671789),
+                (24.999999999999996, 80.92053252671789),
                 (0, 80),
-                (0, 76.66666666666667),
-                (0, 73.33333333333333),
                 (0, 70),
-                (11.94262888488008, 71.29264444333815),
-                (24.999999999999996, 71.7438759890997),
-                (38.05737111511993, 71.29264444333815),
+                (25, 71.7438759890997),
                 (50, 70),
             ],
             holes=[
                 [
                     (45, 72),
-                    (45, 75),
                     (45, 78),
                     (25, 78.70451161084236),
                     (5, 78),
-                    (4.999999999999999, 75),
                     (5, 72),
-                    (18.1052765936037, 72.90478732278757),
-                    (31.894723406396295, 72.90478732278757),
+                    (25, 73.02127815507072),
                     (45, 72),
                 ],
             ],
@@ -139,8 +124,29 @@ def test_densify_with_holes():
     ]
 
 
+def test_densify_idempotent():
+    polygon = Polygon([
+        (50, 75),
+        (10, 80),
+        (0, 77),
+        (40, 70),
+        (50, 75),
+    ])
+
+    transformation = densify_polygon(50_000)
+
+    densified_polygons = list(transformation(polygon))
+    double_densified_polygons = [
+        poly
+        for densified_polygon in densified_polygons
+        for poly in transformation(densified_polygon)
+    ]
+
+    assert densified_polygons == double_densified_polygons
+
+
 def test_densify_incomplete():
-    assert list(densify_polygon(500000)(Polygon())) == [Polygon()]
+    assert list(densify_polygon(50_000)(Polygon())) == [Polygon()]
 
 
 def test_densify_error():


### PR DESCRIPTION
This PR refactors the module structure, docstrings and readme to reflect what I've learned about the different CMR coordinate systems to make it more clear what coordinate system each function will work correctly in.

Near the poles the geodetic and cartesian systems become very different from eachother. Luckily we can still achieve *approximately* the right polygons using cartesian operations (shapely) if we have a sufficiently dense polygon. This PR adds a 'densify' operation that uses `pygeodesy` to densify a polygon along great circle arcs. This should allow us to continue using cartesian coordinates in CMR, but produce more accurately split polygons by simply adding a densify operation to the start of our tranformation pipelines. 

<details>
<summary>Old densify implementation by maximum line segment length</summary>

Here's an example of how a cartesian rectangle looks after being densified and rendered in webmercator projection:

<img width="723" height="365" alt="image" src="https://github.com/user-attachments/assets/8bc573ec-59ea-4a9e-8eb9-d1d6ecf4529a" />

And a cartesian rectangle with a hole in the middle:
<img width="723" height="365" alt="image" src="https://github.com/user-attachments/assets/66220daa-49ba-4d8d-a7ef-915fee6cfd98" />
</details>

### New implementation based on cross track error
4 point diagonal box in cartesian space
<img width="723" height="365" alt="image" src="https://github.com/user-attachments/assets/9f692e42-f253-4b35-972a-223324429c72" />

Densified with an error tolerance of 50km:
<img width="723" height="365" alt="image" src="https://github.com/user-attachments/assets/2aa179fa-55f1-4fa4-b42e-2461e223892d" />

Densified with an error tolerance of 20km:
<img width="650" height="350" alt="image" src="https://github.com/user-attachments/assets/f0e689c4-b0ea-449b-b155-2b3b590f4e34" />

Densified with an error tolerance of 5km:
<img width="723" height="365" alt="image" src="https://github.com/user-attachments/assets/3c381c2e-916a-4052-a0a6-469ceb331d86" />


With this implementation edges are only densified when they need to be in order to reduce error. For instance edges that run due north/south will not be densified at all since they are the same in both cartesian coordinates and the geodetic great circle model. Similarly, edges that run along the equator will also not be densified, but edges that run parrallel to the equator at a high latitude will be densified quite a lot.

For instance this polygon:
<img width="650" height="350" alt="image" src="https://github.com/user-attachments/assets/809a0d25-f69d-4c19-8692-fb474337e9e8" />

Densified with an error tolerance of 5km:
<img width="650" height="350" alt="image" src="https://github.com/user-attachments/assets/c0e34860-85e8-4fbb-a574-8284b46932de" />

Only results in a small number of points being added along a single edge.


<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>